### PR TITLE
지도 리팩토링

### DIFF
--- a/src/components/common/Map.tsx
+++ b/src/components/common/Map.tsx
@@ -1,0 +1,100 @@
+import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+import { IRecordedPlace } from 'types/post';
+import PlaceModal from 'components/post/PlaceModal';
+
+interface IMapOptions {
+  center: any;
+  level: number;
+}
+interface MapProps {
+  places: IRecordedPlace[];
+}
+
+const Map = ({ places }: MapProps) => {
+  const { kakao } = window;
+  const [isOpenPlace, setIsOpenPlace] = useState<boolean>(false);
+  const [clickedMarkerIdx, setClickedMarkerIdx] = useState<number>(0); // 지도에서 클릭한 마커의 인덱스
+  const [map, setMap] = useState<any>(null);
+
+  // 지도를 불러옵니다
+  useEffect(() => {
+    const container = document.getElementById('map');
+    if (places.length === 0) {
+      // 선택한 장소가 없을 때, 지도에 표시할 default 장소
+      const options: IMapOptions = {
+        center: new kakao.maps.LatLng(33.450701, 126.570667), //지도의 중심좌표
+        level: 4, //지도의 레벨(확대, 축소 정도)
+      };
+      const map = new kakao.maps.Map(container, options);
+      setMap(map);
+    } else {
+      const options: IMapOptions = {
+        center: new kakao.maps.LatLng(33.450701, 126.570667), //지도의 중심좌표
+        level: 4, //지도의 레벨(확대, 축소 정도)
+      };
+      const map = new kakao.maps.Map(container, options);
+      addMarker(map);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (places.length !== 0 && map) {
+      addMarker(map);
+    }
+  }, [places]);
+
+  const addMarker = (newMap: any) => {
+    // 마커 이미지
+    const imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
+      imageSize = new kakao.maps.Size(36, 37); // 마커 이미지의 크기
+
+    // 지도 범위 재설정 위한 바운더리 객체
+    const bounds = new kakao.maps.LatLngBounds();
+    for (let i = 0; i < places.length; i++) {
+      /* 1. 위치 객체 생성 */
+      const placePosition = new kakao.maps.LatLng(places[i].addressY, places[i].addressX);
+
+      /* 2. 해당 위치의 마커 생성 */
+      // 마커 생성
+      const imgOptions = {
+          spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
+          spriteOrigin: new kakao.maps.Point(0, i * 46 + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
+          offset: new kakao.maps.Point(13, 37), // 마커 좌표에 일치시킬 이미지 내에서의 좌표
+        },
+        markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions);
+      const marker = new kakao.maps.Marker({
+        position: placePosition, // 마커의 위치
+        image: markerImage,
+        map: newMap,
+      });
+      // 마커에 클릭 이벤트를 등록합니다
+      kakao.maps.event.addListener(marker, 'click', function () {
+        setIsOpenPlace(true);
+        setClickedMarkerIdx(i);
+      });
+
+      /* 3. 지도 범위 재설정 */
+      bounds.extend(new kakao.maps.LatLng(places[i].addressY, places[i].addressX));
+    }
+    newMap.setBounds(bounds);
+    setMap(newMap);
+  };
+
+  return (
+    <MapLayout>
+      <MapBox id="map" />
+      {isOpenPlace ? <PlaceModal placeIdx={clickedMarkerIdx} handleModalClose={() => setIsOpenPlace(false)} /> : null}
+    </MapLayout>
+  );
+};
+export default Map;
+
+const MapLayout = styled.div`
+  padding: 1.5rem 0;
+`;
+const MapBox = styled.div`
+  width: 100%;
+  height: 20rem;
+  border-radius: 1.2rem;
+`;

--- a/src/components/post/KeywordPlaceSearch.tsx
+++ b/src/components/post/KeywordPlaceSearch.tsx
@@ -3,97 +3,24 @@
 import styled from 'styled-components';
 import { IPlaceKakao } from 'types/kakaoMap';
 import { IRecordedPlace } from 'types/post';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import searchIcon from '../../assets/icons/search.svg';
 import SearchModal from './SearchModal';
-import PlaceModal from './PlaceModal';
 import { recordedPlacesState } from '\brecoil/atoms/recordedPlacesState';
 import { useRecoilState } from 'recoil';
+import Map from 'components/common/Map';
 
-interface IMapOptions {
-  center: any;
-  level: number;
-}
+// interface IMapOptions {
+//   center: any;
+//   level: number;
+// }
 
 const KeywordPlaceSearch = () => {
-  const { kakao } = window;
-  const [map, setMap] = useState<any>(null);
   const [results, setResults] = useState<IPlaceKakao[]>([]); // 키워드 검색 결과들을 담는 배열
-  const [markers, setMarkers] = useState<any>([]); // 마커들을 담는 배열
 
   const [isOpenSearch, setIsOpenSearch] = useState<boolean>(false);
-  const [isOpenPlace, setIsOpenPlace] = useState<boolean>(false);
-  const [clickedMarkerIdx, setClickedMarkerIdx] = useState<number>(0); // 지도에서 클릭한 마커의 인덱스
 
   const [places, setPlaces] = useRecoilState<IRecordedPlace[]>(recordedPlacesState); //추가한 데이트 장소
-
-  // 지도를 불러옵니다
-  useEffect(() => {
-    const container = document.getElementById('map');
-
-    // 선택한 장소가 없을 때, 지도에 표시할 default 장소
-    if (places.length === 0) {
-      const options: IMapOptions = {
-        center: new kakao.maps.LatLng(33.450701, 126.570667), //지도의 중심좌표
-        level: 4, //지도의 레벨(확대, 축소 정도)
-      };
-      const newMap = new kakao.maps.Map(container, options);
-      setMap(newMap);
-    } else {
-      const options: IMapOptions = {
-        center: new kakao.maps.LatLng(places[places.length - 1].addressX, places[places.length - 1].addressY), //지도의 중심좌표
-        level: 4, //지도의 레벨(확대, 축소 정도)
-      };
-      const newMap = new kakao.maps.Map(container, options);
-      setMap(newMap);
-    }
-  }, []);
-
-  // 지도에 마커를 표시합니다
-  useEffect(() => {
-    const newMap = map;
-    if (markers.length !== 0) {
-      // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-      // LatLngBounds 객체에 좌표를 추가합니다
-      const bounds = new kakao.maps.LatLngBounds();
-
-      for (let i = 0; i < markers.length; i++) {
-        markers[i].setMap(newMap);
-        bounds.extend(new kakao.maps.LatLng(places[i].addressY, places[i].addressX));
-        map.setBounds(bounds);
-      }
-      setMap(newMap);
-    }
-  }, [markers]);
-
-  /**
-   * 마커를 생성하고 지도에 마커를 표시함
-   * @param position new kakao.maps.LatLng(y좌표, x좌표)
-   * @param idx 마커 번호 (0부터 시작, 표시될 번호 - 1)
-   */
-  function addMarker(position: any, order: number) {
-    const imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
-      imageSize = new kakao.maps.Size(36, 37), // 마커 이미지의 크기
-      imgOptions = {
-        spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
-        spriteOrigin: new kakao.maps.Point(0, order * 46 + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
-        offset: new kakao.maps.Point(13, 37), // 마커 좌표에 일치시킬 이미지 내에서의 좌표
-      },
-      markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
-      // 마커 생성
-      marker = new kakao.maps.Marker({
-        position: position, // 마커의 위치
-        image: markerImage,
-      });
-
-    // 마커에 클릭 이벤트를 등록합니다
-    kakao.maps.event.addListener(marker, 'click', function () {
-      setIsOpenPlace(true);
-      setClickedMarkerIdx(order);
-    });
-
-    setMarkers((prevMarkers: any) => [...prevMarkers, marker]); // 배열에 생성된 마커를 추가합니다
-  }
 
   /**
    * 선택한 장소를 데이트 코스에 추가하고 지도에 표시하는 함수
@@ -103,7 +30,7 @@ const KeywordPlaceSearch = () => {
     setIsOpenSearch(false);
     // 데이트 코스에 추가합니다
     // 장소 데이터를 업데이트합니다
-    const curOrder = markers.length;
+    const curOrder = places.length + 1;
     const curPlaceKakao = results[index];
     const guStartIdx = curPlaceKakao.road_address_name.indexOf(' ') + 1;
     const guEndIdx = curPlaceKakao.road_address_name.indexOf('구 ') + 1;
@@ -120,44 +47,27 @@ const KeywordPlaceSearch = () => {
         image: [],
       },
     ]);
-    // 마커를 생성하고 지도에 표시합니다
-    const placePosition = new kakao.maps.LatLng(results[index].y, results[index].x);
-    addMarker(placePosition, places.length);
   }
   return (
     <KeywordPlaceSearchLayout>
-      <MapCol>
-        <MapBox id="map" />
-      </MapCol>
-      <>
-        <SearchContainer onClick={() => setIsOpenSearch(true)}>
-          <SearchContainder placeholder="추가할 코스를 검색해주세요" />
-          <SearchIcon src={searchIcon} alt="검색 아이콘" />
-        </SearchContainer>
-        {isOpenSearch ? (
-          <SearchModal
-            handleModalClose={() => setIsOpenSearch(false)}
-            setResultsParent={setResults}
-            handleClickListItem={handleClickListItem}
-          />
-        ) : null}
-        {isOpenPlace ? <PlaceModal placeIdx={clickedMarkerIdx} handleModalClose={() => setIsOpenPlace(false)} /> : null}
-      </>
+      <Map places={places} />
+      <SearchContainer onClick={() => setIsOpenSearch(true)}>
+        <SearchContainder placeholder="추가할 코스를 검색해주세요" />
+        <SearchIcon src={searchIcon} alt="검색 아이콘" />
+      </SearchContainer>
+      {isOpenSearch && (
+        <SearchModal
+          handleModalClose={() => setIsOpenSearch(false)}
+          setResultsParent={setResults}
+          handleClickListItem={handleClickListItem}
+        />
+      )}
     </KeywordPlaceSearchLayout>
   );
 };
 const KeywordPlaceSearchLayout = styled.div`
   margin-bottom: 1rem;
 `;
-const MapCol = styled.div`
-  padding: 1.5rem 0;
-`;
-const MapBox = styled.div`
-  width: 100%;
-  height: 20rem;
-  border-radius: 1.2rem;
-`;
-
 /* Search Box */
 const SearchContainer = styled.section`
   position: relative;

--- a/src/components/post/KeywordPlaceSearch.tsx
+++ b/src/components/post/KeywordPlaceSearch.tsx
@@ -10,11 +10,6 @@ import { recordedPlacesState } from '\brecoil/atoms/recordedPlacesState';
 import { useRecoilState } from 'recoil';
 import Map from 'components/common/Map';
 
-// interface IMapOptions {
-//   center: any;
-//   level: number;
-// }
-
 const KeywordPlaceSearch = () => {
   const [results, setResults] = useState<IPlaceKakao[]>([]); // 키워드 검색 결과들을 담는 배열
 


### PR DESCRIPTION
지도 컴포넌트를 따로 뺐습니다!

**기존:**
KeywordPlaceSearch.tsx에서 키워드 검색+지도+장소모달 한 번에 처리
**리팩토링 후:**
KeywordPlaceSearch.tsx에서 키워드 검색
-> 검색해서 선택한 장소 데이터 (recordedPlacesState) Map.tsx에 전달
-> Map.tsx에서 해당 장소 지도에 마커 표시, 장소 모달 연결

* 글 작성 페이지 -> (뒤로가기) 해시태그 선택 페이지 -> (다시 앞으로) 글 작성 페이지 이동 시
기존 지도 UI 유지 안됐던 문제 해결